### PR TITLE
Some optimization

### DIFF
--- a/main.rs
+++ b/main.rs
@@ -1,14 +1,12 @@
 use aws_lambda_events::s3::S3Event;
-use flate2::read::GzDecoder;
+use flate2::bufread::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use flate2::GzBuilder;
 use lambda_runtime::{handler_fn, Error};
 use serde_json::Value;
-use std::fs::File;
 use std::io::prelude::*;
-use std::io::BufReader;
-use std::io::Read;
+use std::io::{BufRead, BufReader};
 
 #[tokio::main]
 async fn main() -> Result<(), lambda_runtime::Error> {
@@ -38,46 +36,35 @@ async fn handler(req: Value, _ctx: lambda_runtime::Context) -> Result<(), Box<Er
             .unwrap()
             .into_bytes();
 
-        let mut d: GzDecoder<&[u8]> = GzDecoder::new(&data[..]);
-        let mut csv_data: String = String::new();
-        d.read_to_string(&mut csv_data).unwrap();
+        let decoder: BufReader<GzDecoder<&[u8]>> = BufReader::new(GzDecoder::new(&data[..]));
 
-        let split: std::str::Lines<'_> = csv_data.lines();
-        let result_vector: Vec<&str> = split.collect();
+        let output = Vec::new();
+        let mut encoder: GzEncoder<Vec<u8>> = GzBuilder::new()
+            .filename("tab_converted.txt")
+            .write(output, Compression::default());
 
-        let mut tab_converted: String = String::new();
-        for line in result_vector.iter().skip(1) {
+        for line in decoder.lines().skip(1) {
+            let line = line.unwrap();
             let date: &&str = &line[0..14].trim();
             let serial_number: &&str = &line[15..35].trim();
             let model: &&str = &line[36..78].trim();
             let capacity_bytes: &&str = &line[79..97].trim();
             let failure: &&str = &line[98..108].trim();
-            let tab_line: String = format!(
-                "{}\t{}\t{}\t{}\t{}\n",
+            writeln!(
+                &mut encoder,
+                "{}\t{}\t{}\t{}\t{}",
                 date, serial_number, model, capacity_bytes, failure
-            );
-            tab_converted.push_str(&tab_line);
+            )
+            .unwrap();
         }
-        let f: File = File::create("/tmp/file.gz").expect("failed to create file");
-        let mut gz: GzEncoder<File> = GzBuilder::new()
-            .filename("tab_converted.txt")
-            .write(f, Compression::default());
-        gz.write_all(tab_converted.as_bytes())
-            .expect("failed to write bytes to file");
-        gz.finish().expect("failed to flush bytes to file");
-
-        let file: File = File::open("/tmp/file.gz").expect("problem reading file");
-        let mut reader: BufReader<File> = BufReader::new(file);
-        let mut buffer: Vec<u8> = Vec::new();
-
-        reader.read_to_end(&mut buffer).expect("error");
+        let output = encoder.finish().expect("failed to flush bytes to file");
 
         let remote_uri: &String = &key.replace("fixed_width_raw/", "tab_converted/");
         s3_client
             .put_object()
             .bucket(&bucket_name)
             .key(remote_uri)
-            .body(buffer.into())
+            .body(output.into())
             .send()
             .await
             .unwrap();


### PR DESCRIPTION
Hey there,

After reading your blog post at https://www.confessionsofadataguy.com/aws-lambdas-python-vs-rust-performance-and-cost-savings/ I was surprised that the difference between Python and Rust was a lot less than I expected it judging by my previous experience.

I took a few moments to look at the code and found you're caching a lot of data multiple times, whereas Rust provides awesome capabilities to stream data through the process with iterators. In addition I found you're writing a file and reading it back where you could just write the compressed data directly to memory.

This MR contains a first commit that formats the code with `rustfmt`. My tooling does apply `rustfmt` automatically, so in order to keep the changes of the second commit easier to understand, I applied it first.

I'd be curious how the numbers of this slightly improved version compare to the numbers you published on your blog, and of course also how they compare to the Python version. This is of course just a few moments that I took to look at it, and I have *close to no* experience with Amazon services, so please bear with me if I did something wrong here.